### PR TITLE
Improve accessibility landmarks and labels

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -45,7 +45,7 @@ import Logo from "@/components/Logo.astro";
 
       <div class="md:hidden">
         <div class="dropdown dropdown-end">
-          <button tabindex="0" class="btn btn-ghost btn-circle">
+          <button tabindex="0" class="btn btn-ghost btn-circle" aria-label="Abrir menu de navegação">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h7" />
             </svg>

--- a/src/components/PaginaInicial.astro
+++ b/src/components/PaginaInicial.astro
@@ -4,9 +4,11 @@ import Footer from "@/components/Footer.astro";
 import Header from "@/components/Header.astro";
 ---
 
-<div class="flex min-h-svh w-full flex-col items-center justify-center">
+<div class="flex min-h-svh w-full flex-col items-center">
   <Header />
-  <Conteudo />
+  <main class="flex w-full flex-1 flex-col items-center justify-center">
+    <Conteudo />
+  </main>
   <!-- <Testemunho /> -->
   <Footer />
 </div>


### PR DESCRIPTION
## Summary
- add an accessible label to the mobile navigation button
- wrap the home page content in a main landmark for semantic structure

## Testing
- pnpm check
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939be5da5f48325b8da5d97a378b3b1)