### PR TITLE
Inline critical stylesheets and optimize images

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://astro.build/config
 export default defineConfig({
+  build: {
+    inlineStylesheets: "always",
+  },
   // integrations: [
   //   tailwind({
   //     ,

--- a/src/components/Conteudo.astro
+++ b/src/components/Conteudo.astro
@@ -1,7 +1,7 @@
 ---
 import Fotos from "@/components/Fotos.astro";
 import DidaticaBanner from "@/assets/didatica.jpg";
-import { Image } from "astro:assets";
+import { Picture } from "astro:assets";
 
 const ctaLink = "https://pay.hotmart.com/W102120628U";
 ---
@@ -15,10 +15,13 @@ const ctaLink = "https://pay.hotmart.com/W102120628U";
         rel="noreferrer"
         class="block overflow-hidden rounded-2xl shadow-lg transition hover:shadow-xl"
       >
-        <Image
+        <Picture
           src={DidaticaBanner}
           alt="Banner da imersão A Didática"
           loading="eager"
+          widths={[480, 768, 1080, 1366]}
+          formats={["avif", "webp"]}
+          sizes="(max-width: 640px) 100vw, (max-width: 1280px) 90vw, 1366px"
           class="h-auto w-full object-cover"
         />
       </a>

--- a/src/components/Fotos.astro
+++ b/src/components/Fotos.astro
@@ -11,18 +11,23 @@ const carrosel = [Foto, Foto1, Foto2, Foto3];
 <div class="carousel relative w-full" id="carousel-fotos">
   {
     carrosel.map((foto, index) => (
-      <div 
-        id={"foto" + index} 
+      <div
+        id={"foto" + index}
         class="carousel-item relative w-full"
         data-carousel-item={index}
       >
-        <Picture
-          src={foto}
-          loading={index === 0 ? "eager" : "lazy"}
-          alt="Foto de alunos treinando Jiu-Jitsu na Escola de Jiu-Jitsu Azambuja-Behring."
-          class="w-full bg-cover"
-          layout="constrained"
-        />
+        <div class="w-full">
+          <Picture
+            src={foto}
+            loading={index === 0 ? "eager" : "lazy"}
+            alt="Foto de alunos treinando Jiu-Jitsu na Escola de Jiu-Jitsu Azambuja-Behring."
+            widths={[640, 960, 1280]}
+            sizes="(max-width: 640px) 100vw, (max-width: 1024px) 90vw, 1280px"
+            formats={["avif", "webp", "jpeg"]}
+            class="h-full w-full object-cover"
+            layout="constrained"
+          />
+        </div>
         <div class="absolute top-1/2 right-5 left-5 flex -translate-y-1/2 transform justify-between">
           <button
             type="button"

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -13,5 +13,9 @@ const { className = "w-24", loading = "eager" } = Astro.props;
     loading={loading}
     src={myImage}
     alt="Logo. Escrito em volta do círculo Escola de Jiu-Jitsu Azambuja, o logo da Sylvio Behring Association (SBA) e Sylvio Behring. Dentro há um logo triangular formado pela adaptação das letras A e Z, com o escito embaixo: sistema progressivo de jiu-jitsu."
+    width={200}
+    height={200}
+    format="webp"
+    class="h-auto w-full"
   />
 </div>


### PR DESCRIPTION
## Summary
- inline generated stylesheets to remove render-blocking CSS requests
- provide responsive sources and stronger compression for the Didática banner and carousel photos
- constrain the logo export to a smaller webp variant to cut transfer size

## Testing
- pnpm check

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6939bed8aec88325aa2ffbeeeede86b5)